### PR TITLE
MaryiaF/fix: Balance loader, platform switcher, labels reports and cashier aren't aligned on Firefox during loading data

### DIFF
--- a/src/botPage/view/deriv/layout/Header/components/menu-links.jsx
+++ b/src/botPage/view/deriv/layout/Header/components/menu-links.jsx
@@ -3,22 +3,24 @@ import config from '../../../../../../app.config';
 
 const MenuLinks = () => (
     <div className="header__menu-item header__menu-links client_logged_in">
-        {config.reports.visible && <a className="url-reports-positions header__menu-links-item" href={config.reports.url}>
-            <span>
+        {config.reports.visible && <div><a className="url-reports-positions header__menu-links-item" href={config.reports.url}>
+            <div className="header__icon-container">
                 <img className="header__icon-text reports-icon" src="image/deriv/ic-reports.svg" />
-            </span>
-            <p>
+            </div>
+            <div>
+            <p className="header__menu-item_label">
                 {config.reports.label}
             </p>
-        </a>}
-        {config.reports.visible && <a className="url-cashier-deposit header__menu-links-item" href={config.cashier.url}>
-            <span>
+            </div>
+        </a></div>}
+        {config.reports.visible && <div><a className="url-cashier-deposit header__menu-links-item" href={config.cashier.url}>
+            <div className="header__icon-container">
                 <img id="cashier_icon" className="header__icon-text" src="image/deriv/ic-cashier.svg" />
-            </span>
-            <p>
+            </div>
+            <p className="header__menu-item_label">
                 {config.cashier.label}
             </p>
-        </a>}
+        </a></div>}
     </div>
 );
 

--- a/src/botPage/view/deriv/layout/Header/components/menu-links.jsx
+++ b/src/botPage/view/deriv/layout/Header/components/menu-links.jsx
@@ -6,14 +6,18 @@ const MenuLinks = () => (
         {config.reports.visible && <a className="url-reports-positions header__menu-links-item" href={config.reports.url}>
             <span>
                 <img className="header__icon-text reports-icon" src="image/deriv/ic-reports.svg" />
-                {config.reports.label}
             </span>
+            <p>
+                {config.reports.label}
+            </p>
         </a>}
         {config.reports.visible && <a className="url-cashier-deposit header__menu-links-item" href={config.cashier.url}>
             <span>
                 <img id="cashier_icon" className="header__icon-text" src="image/deriv/ic-cashier.svg" />
-                {config.cashier.label}
             </span>
+            <p>
+                {config.cashier.label}
+            </p>
         </a>}
     </div>
 );

--- a/static/css/deriv/header.scss
+++ b/static/css/deriv/header.scss
@@ -57,6 +57,7 @@
 
             > * {
                 display: inline-flex;
+                flex: 1;
             }
         }
         &-item {
@@ -86,6 +87,7 @@
                 text-transform: capitalize;
                 padding: 0 8px;
                 word-wrap: break-word;
+                align-items: center;
                 @include mobile{
                     width:100%;
                     justify-content: space-between;
@@ -117,12 +119,14 @@
             }
         }
         &-right{
+            justify-content: flex-end;
             > * {
                 align-self: center;
             }
             &-loader{
                 width: 100%;
                 height: 100%;
+                text-align: right;
                 & > svg{
                     max-height: 80%;
                     margin-right:10px;

--- a/static/css/deriv/header.scss
+++ b/static/css/deriv/header.scss
@@ -66,6 +66,15 @@
             &.disabled {
                 cursor: not-allowed;
             }
+
+            &_label {
+                line-height: initial;
+
+                @include mobile {
+                    margin: 0 0 !important;
+                    padding-bottom: 0.2rem;
+                }
+            }
         }
         &-links {
             display: flex;
@@ -74,6 +83,7 @@
             @include mobile{
                 flex-direction: column;
                 height: 45px;
+                margin-top: 0.1rem;
             }
 
             a {
@@ -90,9 +100,10 @@
                 align-items: center;
                 @include mobile{
                     width:100%;
-                    justify-content: space-between;
                     max-width: unset;
-                    padding: 16px 0 16px 24px;
+                    padding: 10.5px 0 10.5px 24px;
+                    justify-content: flex-start;
+                    align-items: center;
                 }
             }
             &-item {
@@ -140,7 +151,7 @@
         }
     }
     &__hamburger {
-        width: 16px;
+        max-width: 16px;
         height: 16px;
         transform: scale(1.3);
         align-self: center;
@@ -187,8 +198,17 @@
         height: 16px;
         width: 16px;
 
+        &-container {
+                display: flex;
+                align-items: center;
+        }
+
         &-text {
             margin-right: 0.5rem;
+
+            @include desktop {
+                margin-top: 0.25rem;
+            }
         }
         &-button {
             height: 20px;


### PR DESCRIPTION
Fix: Balance loader, platform switcher, labels reports and cashier aren't aligned on Firefox during loading data
Recommendation: `account_switcher_loader` set/hardcode as `true` to check how it works