### PR TITLE
fix:  TrackJs - Cannot read properties of null (reading 'disconnect')

### DIFF
--- a/src/botPage/view/blockly/blocks/trade/index.js
+++ b/src/botPage/view/blockly/blocks/trade/index.js
@@ -15,7 +15,9 @@ const bcMoveAboveInitializationsDown = block => {
     if (parent) {
         const initializations = block.getInput('INITIALIZATION').connection;
         const ancestor = findTopParentBlock(parent);
-        parent.nextConnection.disconnect();
+        if(parent.nextConnection?.disconnect() !== null){
+            parent.nextConnection.disconnect();
+        }
         initializations.connect((ancestor || parent).previousConnection);
     }
     block.setPreviousStatement(false);


### PR DESCRIPTION
## Changes

-   fix:  TrackJs - Cannot read properties of null (reading 'disconnect')

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

