### PR TITLE
fix: changed latest-staging to latest in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
     parameters:
       docker_latest_image_tag:
         type: string
-        default: "latest-staging"
+        default: "latest"
       docker_image_tag:
         type: string
         default: ${CIRCLE_SHA1}


### PR DESCRIPTION
## Scope
- experimental change in config to fix the underlying issue

![image](https://github.com/deriv-com/binary-bot/assets/90243468/bdca29b7-28a9-4e5e-bde5-8b342882e141)


## Change (in .circleci/config.yml)
from 
```
   docker_latest_image_tag:
        type: string
        default: "latest-staging"
```

to 

```
   docker_latest_image_tag:
        type: string
        default: "latest"
```