### PR TITLE
fix: Unable to open candle, hollow and ohlc chart, fix api call tick_…

### DIFF
--- a/src/botPage/common/TicksService.js
+++ b/src/botPage/common/TicksService.js
@@ -234,7 +234,7 @@ export default class TicksService {
         });
     }
     requestStream(options) {
-        const { style, is_chart_ticks } = options;
+        const { style, is_chart_ticks, is_chart_candles } = options;
         const stringified_options = JSON.stringify(options);
 
         if (style === 'ticks') {
@@ -253,7 +253,11 @@ export default class TicksService {
         }
 
         if (style === 'candles') {
-            if (!this.candles_promise || this.candles_promise.stringified_options !== stringified_options) {
+            if (
+                !this.candles_promise ||
+                this.candles_promise.stringified_options !== stringified_options ||
+                is_chart_candles
+            ) {
                 this.candles_promise = {
                     promise: this.requestPipSizes().then(() => this.requestTicks(options)),
                     stringified_options,
@@ -276,7 +280,7 @@ export default class TicksService {
             style,
         };
 
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
             doUntilDone(() => this.api.send(request_object))
                 .then(r => {
                     if (style === 'ticks') {

--- a/src/botPage/common/TicksService.js
+++ b/src/botPage/common/TicksService.js
@@ -234,11 +234,15 @@ export default class TicksService {
         });
     }
     requestStream(options) {
-        const { style } = options;
+        const { style, is_chart_ticks } = options;
         const stringified_options = JSON.stringify(options);
 
         if (style === 'ticks') {
-            if (!this.ticks_history_promise || this.ticks_history_promise.stringified_options !== stringified_options) {
+            if (
+                !this.ticks_history_promise ||
+                this.ticks_history_promise.stringified_options !== stringified_options ||
+                is_chart_ticks
+            ) {
                 this.ticks_history_promise = {
                     promise: this.requestPipSizes().then(() => this.requestTicks(options)),
                     stringified_options,

--- a/src/botPage/view/Dialogs/Chart.js
+++ b/src/botPage/view/Dialogs/Chart.js
@@ -1,24 +1,16 @@
 import React from 'react';
-import {
-    ChartMode,
-    DrawTools,
-    setSmartChartsPublicPath,
-    Share,
-    SmartChart,
-    StudyLegend,
-    ToolbarWidget,
-    Views,
-} from '@deriv/deriv-charts';
+import { setSmartChartsPublicPath, SmartChart } from '@deriv/deriv-charts';
 import { getLanguage } from '@storage';
 import { translate } from '@i18n';
 import Dialog from './Dialog';
 import ChartTicksService from '../../common/ChartTicksService';
 import { observer as globalObserver } from '../../../common/utils/observer';
 import api from '../deriv/api';
+import ToolbarWidgets from './ToolbarWidgets';
 
 setSmartChartsPublicPath('./js/');
 
-export const BarrierTypes = {
+const BarrierTypes = {
     CALL: 'ABOVE',
     PUT: 'BELOW',
     EXPIRYRANGE: 'BETWEEN',
@@ -106,6 +98,7 @@ const ChartContent = () => {
             listeners[getKey(request)] = ticksService.monitor({
                 symbol,
                 callback,
+                is_chart_ticks: true,
             });
         }
     };
@@ -131,29 +124,6 @@ const ChartContent = () => {
 
     const renderTopWidgets = () => <span />;
 
-    const renderToolbarWidgets = () => (
-        <ToolbarWidget>
-            <ChartMode
-                onChartType={chart_type =>
-                    setState({
-                        ...state,
-                        chart_type,
-                    })
-                }
-                onGranularity={granularity =>
-                    setState({
-                        ...state,
-                        granularity,
-                    })
-                }
-            />
-            <StudyLegend searchInputClassName='data-hj-whitelist' />
-            <DrawTools />
-            <Views searchInputClassName='data-hj-whitelist' />
-            <Share />
-        </ToolbarWidget>
-    );
-
     if (!show) return null;
 
     return (
@@ -170,7 +140,7 @@ const ChartContent = () => {
             requestSubscribe={requestSubscribe}
             settings={{ language: getLanguage() }}
             symbol={state.symbol}
-            toolbarWidget={renderToolbarWidgets}
+            toolbarWidget={() => <ToolbarWidgets setState={setState} />}
             topWidgets={renderTopWidgets}
         />
     );

--- a/src/botPage/view/Dialogs/Chart.js
+++ b/src/botPage/view/Dialogs/Chart.js
@@ -126,6 +126,8 @@ const ChartContent = () => {
 
     if (!show) return null;
 
+    const handleStateChange = state_property => setState(state_property);
+
     return (
         <SmartChart
             barriers={[]}
@@ -140,7 +142,7 @@ const ChartContent = () => {
             requestSubscribe={requestSubscribe}
             settings={{ language: getLanguage() }}
             symbol={state.symbol}
-            toolbarWidget={() => <ToolbarWidgets handleStateChange={setState} />}
+            toolbarWidget={() => <ToolbarWidgets handleStateChange={handleStateChange} />}
             topWidgets={renderTopWidgets}
         />
     );

--- a/src/botPage/view/Dialogs/Chart.js
+++ b/src/botPage/view/Dialogs/Chart.js
@@ -140,7 +140,7 @@ const ChartContent = () => {
             requestSubscribe={requestSubscribe}
             settings={{ language: getLanguage() }}
             symbol={state.symbol}
-            toolbarWidget={() => <ToolbarWidgets setState={setState} />}
+            toolbarWidget={() => <ToolbarWidgets handleStateChange={setState} />}
             topWidgets={renderTopWidgets}
         />
     );

--- a/src/botPage/view/Dialogs/Chart.js
+++ b/src/botPage/view/Dialogs/Chart.js
@@ -93,6 +93,7 @@ const ChartContent = () => {
                 symbol,
                 granularity,
                 callback,
+                is_chart_candles: true,
             });
         } else {
             listeners[getKey(request)] = ticksService.monitor({

--- a/src/botPage/view/Dialogs/ToolbarWidgets.jsx
+++ b/src/botPage/view/Dialogs/ToolbarWidgets.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ChartMode, DrawTools, Share, StudyLegend, ToolbarWidget, Views } from '@deriv/deriv-charts';
+
+// eslint-disable-next-line react/prop-types
+const ToolbarWidgets = ({ setState }) => (
+    <ToolbarWidget>
+        <ChartMode
+            onChartType={chart_type =>
+                setState({
+                    chart_type,
+                })
+            }
+            onGranularity={granularity =>
+                setState({
+                    granularity,
+                })
+            }
+        />
+        <StudyLegend searchInputClassName='data-hj-whitelist' />
+        <DrawTools />
+        <Views searchInputClassName='data-hj-whitelist' />
+        <Share />
+    </ToolbarWidget>
+);
+
+export default ToolbarWidgets;

--- a/src/botPage/view/Dialogs/ToolbarWidgets.jsx
+++ b/src/botPage/view/Dialogs/ToolbarWidgets.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ChartMode, DrawTools, Share, StudyLegend, ToolbarWidget, Views } from '@deriv/deriv-charts';
 
 // eslint-disable-next-line react/prop-types
-const ToolbarWidgets = ({ setState }) => (
+const ToolbarWidgets = ({ handleStateChange }) => (
     <ToolbarWidget>
         <ChartMode
             onChartType={chart_type =>
-                setState({
+                handleStateChange({
                     chart_type,
                 })
             }
             onGranularity={granularity =>
-                setState({
+                handleStateChange({
                     granularity,
                 })
             }
@@ -22,5 +23,9 @@ const ToolbarWidgets = ({ setState }) => (
         <Share />
     </ToolbarWidget>
 );
+
+ToolbarWidgets.propTypes = {
+    handleStateChange: PropTypes.func,
+};
 
 export default ToolbarWidgets;


### PR DESCRIPTION
…history- time interval 1tick

## Changes

-   fix: Unable to open candle, hollow and ohlc chart, 
-   fix: API call `tick_history` for time interval 1 tick, when the user tries to click '1tick' again
-   fix: chart and time interval are not loaded if you switch from one to the second and then back to the previous one, only candles (minutes)

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release

