### PR TITLE
[BOT] chore: update text-transform of modal buttons

### DIFF
--- a/src/components/common/deriv-app-modal/deriv-app-modal.scss
+++ b/src/components/common/deriv-app-modal/deriv-app-modal.scss
@@ -111,6 +111,7 @@
             margin: 4px;
             font-weight: 600;
             font-size: medium;
+            text-transform: none;
         }
         &-primary-btn {
             background: var(--button-primary-default);


### PR DESCRIPTION
## Changes:

- Currently, all the buttons have text-transform: capitalized style applied in it
- For this modal, the button shouldn't have any text-transform applied
- Removed the text-transform removed only for this modal

<img width="807" alt="Screenshot 2023-11-22 at 11 05 50 AM" src="https://github.com/deriv-com/binary-bot/assets/129021108/2f389081-b6f1-4464-be71-11163eff825d">
