### PR TITLE
Farabi/bot-1179/remove onboarding tour from binary bot

### DIFF
--- a/src/components/Header/account-actions.jsx
+++ b/src/components/Header/account-actions.jsx
@@ -8,7 +8,6 @@ import { generateDerivLink } from '@utils';
 import { setActiveLoginId, getClientAccounts, syncWithDerivApp } from '@storage';
 import { translate } from '@i18n';
 import Modal from '@components/common/modal';
-import Tour, { TourTargets } from '@components/common/tour';
 import {
     setAccountSwitcherLoader,
     setAccountSwitcherId,
@@ -147,8 +146,6 @@ const AccountActions = () => {
                     <AccountSwitchModal is_bot_running={is_bot_running} onClose={onClose} onAccept={onAccept} />
                 </Modal>
             )}
-            <TourTargets />
-            <Tour />
         </React.Fragment>
     );
 };

--- a/src/components/Header/auth-buttons.jsx
+++ b/src/components/Header/auth-buttons.jsx
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import config from '@config';
 import { translate } from '@i18n';
 import { setIsHeaderLoaded } from '@redux-store/ui-slice';
-import Tour, { TourTargets } from '@components/common/tour';
 import { saveBeforeUnload } from '../../blockly/utils';
 
 const AuthButtons = () => {
@@ -32,8 +31,6 @@ const AuthButtons = () => {
             >
                 {translate(config.signup.label)}
             </a>
-            <TourTargets />
-            <Tour />
         </div>
     );
 };


### PR DESCRIPTION
## Changes:

Removed onboarding tour from binary bot as we are now showing new modal to redirect clients to deriv bot

