### PR TITLE
[BBOT] sandeep/bot-1273/unable-to-login-after-changing-endpoints

### DIFF
--- a/src/api-base.js
+++ b/src/api-base.js
@@ -4,6 +4,8 @@ import {
     getServerAddressFallback,
     getClientAccounts,
     setClientAccounts,
+    setConfigURL,
+    setConfigAppID,
 } from '@storage';
 import DerivAPIBasic from '@deriv/deriv-api/dist/DerivAPIBasic';
 import { observer as globalObserver } from '@utilities/observer';
@@ -161,11 +163,23 @@ class APIBase {
     }
 
     async getActiveSymbols() {
-        const { active_symbols } = await this.api.send({ active_symbols: 'brief' });
-        this.active_symbols = active_symbols;
-        return {
-            active_symbols,
-        };
+        try {
+            const { active_symbols } = await this.api.send({ active_symbols: 'brief' });
+            this.active_symbols = active_symbols;
+            return {
+                active_symbols,
+            };
+        } catch (err) {
+            if (err.error.code === 'InvalidAppID') {
+                globalObserver.emit('Error', err.error.message);
+                setConfigURL('');
+                setConfigAppID('');
+                window.location.reload();
+            }
+            return {
+                error: err,
+            };
+        }
     }
 }
 

--- a/src/common/appId.js
+++ b/src/common/appId.js
@@ -15,10 +15,10 @@ import { getRelatedDeriveOrigin } from '@utils';
 import GTM from '@utilities/integrations/gtm';
 
 const generateOAuthDomain = () => {
-    const related_deriv_origin = getRelatedDeriveOrigin;
-    const endpointUrl = getCustomEndpoint().url;
+    const related_deriv_origin = getRelatedDeriveOrigin();
+    const endpointUrl = getCustomEndpoint().url || '';
 
-    if (endpointUrl) {
+    if (endpointUrl && endpointUrl.includes('qa')) {
         return endpointUrl;
     }
 

--- a/src/components/Header/auth-buttons.jsx
+++ b/src/components/Header/auth-buttons.jsx
@@ -10,7 +10,7 @@ const AuthButtons = () => {
 
     const onLogin = () => {
         saveBeforeUnload();
-        document.location = config.login.url;
+        document.location = config.login.getURL();
     };
 
     useEffect(() => {

--- a/src/config.js
+++ b/src/config.js
@@ -178,7 +178,7 @@ const getConfig = () => ({
     },
     login: {
         // URL to the common login OAuth page
-        url: getOAuthURL(),
+        getURL: getOAuthURL,
         label: translate('Log in'),
     },
     signup: {


### PR DESCRIPTION
The users are not able to login after changing the Endpoint since the green.binaryws.com and blue.binaryws.com are not allowing to authorize, so the default should be oauth.deriv.com