### PR TITLE
Farabi/fix--update trading view url

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -173,7 +173,7 @@ const getConfig = () => ({
     trading_view_chart: {
         visible: true,
         // URL to the chart
-        url: 'https://tradingview.deriv.com/deriv?hide_banner=1',
+        url: 'https://charts.deriv.com/deriv?hide-signup=true',
         label: translate('Trading View'),
     },
     login: {


### PR DESCRIPTION
## Changes:

Updated trading view url to deriv charts url as we will not be able to use trading view url in the future

