### PR TITLE
[BOT-1344]Rupato/fix: some error on trackJS

### DIFF
--- a/src/utilities/integrations/GoogleDrive.js
+++ b/src/utilities/integrations/GoogleDrive.js
@@ -18,7 +18,7 @@ export const loadExternalScript = (src, async = true) =>
         script.onload = () => resolve(window.external_global_component);
         script.onerror = reject;
 
-        document.body.appendChild(script);
+        document?.body?.appendChild(script);
     });
 
 const errLogger = (err, msg) => {
@@ -71,16 +71,33 @@ class GoogleDriveUtil {
         this.auth = null;
         this.is_authorized = false;
         // Fetch Google API script and initialize class fields
-        loadExternalScript(this.api_url_identity).then(() => this.initUrlIdentity());
-        loadExternalScript(this.api_url_gdrive)
-            .then(() =>
+        this.initializeLoadExternalScript();
+    }
+
+    async initializeLoadExternalScript() {
+        try {
+            await loadExternalScript(this.api_url_identity);
+            await this.initUrlIdentity();
+
+            await loadExternalScript(this.api_url_gdrive);
+            await new Promise((resolve, reject) => {
                 gapi.load(this.auth_scope, async () => {
-                    await gapi.client.load(...this.discovery_docs);
-                })
-            )
-            .then(() => {
-                store.dispatch(setGdReady(true));
+                    try {
+                        await gapi.client.load(...this.discovery_docs);
+                        resolve();
+                    } catch (error) {
+                        reject(error);
+                    }
+                });
             });
+
+            store.dispatch(setGdReady(true));
+        } catch (error) {
+            // Added this console log to suppress the {{ some_error }} on TrackJS,
+            // which occurs when the loading of external scripts fails.
+            // eslint-disable-next-line no-console
+            console.log('Error initializing GoogleDrive:', error);
+        }
     }
 
     initUrlIdentity = () => {

--- a/src/utilities/integrations/GoogleDrive.js
+++ b/src/utilities/integrations/GoogleDrive.js
@@ -18,7 +18,7 @@ export const loadExternalScript = (src, async = true) =>
         script.onload = () => resolve(window.external_global_component);
         script.onerror = reject;
 
-        document?.body?.appendChild(script);
+        document.body.appendChild(script);
     });
 
 const errLogger = (err, msg) => {
@@ -71,27 +71,17 @@ class GoogleDriveUtil {
         this.auth = null;
         this.is_authorized = false;
         // Fetch Google API script and initialize class fields
-        this.initializeLoadExternalScript();
-    }
-
-    async initializeLoadExternalScript() {
         try {
-            await loadExternalScript(this.api_url_identity);
-            await this.initUrlIdentity();
-
-            await loadExternalScript(this.api_url_gdrive);
-            await new Promise((resolve, reject) => {
-                gapi.load(this.auth_scope, async () => {
-                    try {
+            loadExternalScript(this.api_url_identity).then(() => this.initUrlIdentity());
+            loadExternalScript(this.api_url_gdrive)
+                .then(() =>
+                    gapi.load(this.auth_scope, async () => {
                         await gapi.client.load(...this.discovery_docs);
-                        resolve();
-                    } catch (error) {
-                        reject(error);
-                    }
+                    })
+                )
+                .then(() => {
+                    store.dispatch(setGdReady(true));
                 });
-            });
-
-            store.dispatch(setGdReady(true));
         } catch (error) {
             // Added this console log to suppress the {{ some_error }} on TrackJS,
             // which occurs when the loading of external scripts fails.


### PR DESCRIPTION
CU Card: https://app.clickup.com/t/20696747/BOT-1344

In this PR, we attempted to fix the TrackJS {{some error}}. This issue occurred due to an external script. To prevent TrackJS from being flooded with this error, we are logging it into the console as a log instead of an error.

![image](https://github.com/deriv-com/binary-bot/assets/97010868/411679d5-6648-4338-8bce-72a02c0c0b7d)
![image](https://github.com/deriv-com/binary-bot/assets/97010868/f601b4d4-23e4-4132-b118-ecdf825f8936)
