### PR TITLE
chore: :fire: updated gh concolusion workflow version

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Conclusion
-        uses: technote-space/workflow-conclusion-action@v3
+        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
       - name: Send Slack Notification
         uses: "./.github/actions/send_slack_notifications"
         with:

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Conclusion
-        uses: technote-space/workflow-conclusion-action@v3
+        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
       - name: Send Slack Notification
         uses: "./.github/actions/send_slack_notifications"
         with:


### PR DESCRIPTION
## Changes:

- We have updated `technote-space/workflow-conclusion-action` version to the one which is whitelisted 


### Screenshots:

<img width="587" alt="Screenshot 2024-04-16 at 11 22 26 AM" src="https://github.com/deriv-com/binary-bot/assets/90243468/70831757-a4fe-4697-aa3f-5bd3960ecff1">
