### PR TITLE
chore: :fire: updated URL for manage funds and tradershub

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -202,7 +202,7 @@ const getConfig = () => ({
         label: translate('Trader\'s Hub'),
     },
     wallets: {
-        url: generateDerivLink('wallets'),
+        url: generateDerivLink(''),
     },
     deposit: {
         visible: true,
@@ -211,7 +211,7 @@ const getConfig = () => ({
     },
     manage_funds: {
         visible: true,
-        url: `${related_deriv_origin.origin}/wallets/cashier/transfer?lang=${localStorage.getItem('lang')}`,
+        url: `${related_deriv_origin.origin}/redirect?action=payment_transfer&lang=${localStorage.getItem('lang')}`,
         label: translate('Manage Funds'),
     },
 });


### PR DESCRIPTION
## Changes:

For wallet accounts:
- Traders hub should be redirected to [app.deriv.com/](https://app.deriv.com/)
- Manage funds should be redirected to [app.deriv.com/redirect?action=payment_transfer](https://app.deriv.com/redirect?action=payment_transfer)

### Screenshots:

NA
