### PR TITLE
chore: :fire: updated URL for dtrader in the app switcher

### DIFF
--- a/src/components/Header/platform-dropdown.jsx
+++ b/src/components/Header/platform-dropdown.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import config from '@config';
+import CONFIG from '@config';
 import { getLang } from '@storage';
 import { getRelatedDerivOrigin } from '@utils';
 import { useLocation } from 'react-router-dom';
@@ -28,15 +28,7 @@ const PlatformDropdown = React.forwardRef(({ hideDropdown, setIsPlatformSwitcher
     return (
         <div id='platform__dropdown' className='platform__dropdown show'>
             <div id='platform__list' className='platform__dropdown-list' ref={platformDropdownRef}>
-                {config.platforms.map(platform => {
-                    if (platform.title === 'DTrader') {
-                        const related_deriv_origin = getRelatedDerivOrigin();
-                        platform.link = `${related_deriv_origin.origin}/?lang=${lang || 'en'}`;
-                    }
-                    if (platform.title === 'DBot') {
-                        const related_deriv_origin = getRelatedDerivOrigin();
-                        platform.link = `${related_deriv_origin.origin}/bot/?lang=${lang || 'en'}`;
-                    }
+                {CONFIG.platforms.map(platform => {
                     if (platform.title === 'SmartTrader') {
                         const related_deriv_origin = getRelatedDerivOrigin();
                         platform.link = `https://${related_deriv_origin.prefix}smarttrader.deriv.${
@@ -62,7 +54,7 @@ const PlatformDropdown = React.forwardRef(({ hideDropdown, setIsPlatformSwitcher
                     );
                 })}
             </div>
-            <a href={config.tradershub.url}>
+            <a href={CONFIG.tradershub.url}>
                 <span>{translate('Looking for CFDs? Go to Trader\'s Hub')}</span>
             </a>
         </div>

--- a/src/config.js
+++ b/src/config.js
@@ -132,13 +132,13 @@ const getConfig = () => ({
         {
             title: 'DTrader',
             description: translate('A whole new trading experience on a powerful yet easy to use platform.'),
-            link: related_deriv_origin.origin,
+            link: generateDerivLink('dtrader'),
             logo: 'public/images/ic-brand-dtrader.svg',
         },
         {
             title: 'DBot',
             description: translate('Automated trading at your fingertips. No coding needed.'),
-            link: `${related_deriv_origin.origin}/bot`,
+            link: generateDerivLink('bot'),
             logo: 'public/images/ic-brand-dbot.svg',
         },
         {


### PR DESCRIPTION
## Changes:
- Updated URL for Dtrader in the account switcher
- Removed usage of related_deriv_origin
- Utilise generateDerivLink for generating the app.deriv.com URLs such as DTrader and DBot

