### PR TITLE
fix: TrackJS BBot: There was an error listing files from Google Drive - Error: {}

### DIFF
--- a/src/utilities/integrations/GoogleDrive.js
+++ b/src/utilities/integrations/GoogleDrive.js
@@ -151,15 +151,11 @@ class GoogleDriveUtil {
 
                 this.client.requestAccessToken({ prompt: '' });
 
-                const {
-                    result: {
-                        error: {
-                            errors: [{ message, reason }],
-                            code,
-                            status,
-                        },
-                    },
-                } = err;
+                const message = err?.result?.error?.errors[0]?.message;
+                const reason = err?.result?.error?.errors[0]?.reason;
+                const code = err?.result?.error?.code;
+                const status = err?.result?.error?.status;
+
                 const errorObject = {
                     error: {
                         error: {

--- a/src/utilities/integrations/GoogleDrive.js
+++ b/src/utilities/integrations/GoogleDrive.js
@@ -148,16 +148,31 @@ class GoogleDriveUtil {
                     const picker = document.getElementsByClassName('picker-dialog-content')[0];
                     picker.parentNode.removeChild(picker);
                 }, 500);
+
                 this.client.requestAccessToken({ prompt: '' });
+
+                const {
+                    result: {
+                        error: {
+                            errors: [{ message, reason }],
+                            code,
+                            status,
+                        },
+                    },
+                } = err;
+                const errorObject = {
+                    error: {
+                        error: {
+                            message: `${message}, status: ${status}, code: ${code} `,
+                            code: reason,
+                        },
+                    },
+                };
+                trackJSTrack(errorObject);
+            } else {
+                errLogger(JSON.stringify(err, ['message', 'arguments', 'type', 'name']));
             }
-
             const error = translate('There was an error listing files from Google Drive');
-
-            errLogger(
-                JSON.stringify(err, ['message', 'arguments', 'type', 'name']),
-                translate('There was an error listing files from Google Drive')
-            );
-
             globalObserver.emit('Error', error);
         }
     };

--- a/src/utilities/integrations/trackJSTrack.js
+++ b/src/utilities/integrations/trackJSTrack.js
@@ -8,6 +8,7 @@ export const default_errors_to_ignore = [
     'RateLimit',
     'DisconnectError',
     'MarketIsClosed',
+    'authError', // Invalid Credentials, access token's been expired, show pop-up modal to sign in
 ];
 
 export function trackJSTrack(error) {


### PR DESCRIPTION
## Changes:

fix: TrackJS BBot: There was an error listing files from Google Drive - Error: {}

**Findings:** the error happens because of the expired access token (details of the full error message are attached below)

**Steps to reproduce the error:**
1) click the icon on the top menu "connect your google bot to your google drive..." 
2) connect
3) go to inspect elements -> application -> local storage -> change the access token to any expired like: ya29.a0AXooCgtg_GJQfqDC6Ulbt3MfGk90PPUpAcGRo-J7vY32VTPV35X77gGqWTXwKKfxBeiOYE2zk8zGd9bAOPhJ1iTd3L1hxhsy3GtBCjxz8KeIaTTUiDk7flCzT-ukJUs0awSZALP8YzcgrAvHmL2IKVC5TjvqZEo0-gaCgYKARsSARESFQHGX2MipL1jfakn94aD7-yzxQkbbA0169
or like abcd
4) refresh the page
5) click the icon "load new blocks(XML file)
6) choose the checkbox "Google Drive"
7) click the button "Load"
8) look at the console

**Expected behavior** (the team made the decision): 
It should not throw the error to trackJS system since the flow works as expected. Once we get the error we show the popup modal to sign in. 

### Screenshots:

Please provide some screenshots of the change.
<img width="1727" alt="Screenshot 2024-06-04 at 14 41 08" src="https://github.com/deriv-com/binary-bot/assets/103181650/37640de6-13d4-4993-bd96-6a2f7b282e2e">
<img width="1727" alt="Screenshot 2024-06-04 at 09 08 24" src="https://github.com/deriv-com/binary-bot/assets/103181650/535d1ad9-3719-4ac8-9e18-57b35bd43183">

